### PR TITLE
Add provenance singing to published package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,5 +7,16 @@ on:
 
 jobs:
   npm-publish:
-    uses: hemilabs/actions/.github/workflows/npm-publish.yml@main
-    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+      - uses: hemilabs/actions/setup-node-env@main
+      - run: npm run --if-present prepublishOnly
+      - uses: JS-DevTools/npm-publish@9ff4ebfbe48473265867fb9608c047e7995edfa3 # v3.1.1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+provenance=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crypto-shortener",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crypto-shortener",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "commitlint-config-bloq": "^1.1.0",
         "eslint": "^8.57.1",
         "eslint-config-bloq": "^4.4.1",
-        "husky": "^9.1.6",
+        "husky": "^9.1.7",
         "knip": "^5.36.3",
         "lint-staged": "^15.2.10",
         "prettier": "^3.3.3",
@@ -4646,10 +4646,11 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
-      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "husky": "bin.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crypto-shortener",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shorten crypto hashes, addresses with ellipsis",
   "keywords": [
     "address",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "commitlint-config-bloq": "^1.1.0",
     "eslint": "^8.57.1",
     "eslint-config-bloq": "^4.4.1",
-    "husky": "^9.1.6",
+    "husky": "^9.1.7",
     "knip": "^5.36.3",
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",


### PR DESCRIPTION
This PR will be used for testing adding provenance signing to our published packages. See 2978962662f444d20652ddc91657e06fbfb77b80 and the changes required in [this npm doc](https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow).

I had to temporarily remove the usage of the hemilabs action to test this. The provenance flag was added in `.npmrc` as it's not an option available in `JS-DevTools/npm-publish`- See this comment https://github.com/JS-DevTools/npm-publish/issues/88#issuecomment-1524171556

If this works ok, we could update the hemilabs action and rollback this change