### PR TITLE
Rollback code from provenance test

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,16 +7,5 @@ on:
 
 jobs:
   npm-publish:
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: ${{ inputs.fetch-depth }}
-      - uses: hemilabs/actions/setup-node-env@main
-      - run: npm run --if-present prepublishOnly
-      - uses: JS-DevTools/npm-publish@9ff4ebfbe48473265867fb9608c047e7995edfa3 # v3.1.1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+    uses: hemilabs/actions/.github/workflows/npm-publish.yml@main
+    secrets: inherit

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-provenance=true


### PR DESCRIPTION
Now that we've enabled publishing packages with provenance support in the hemilabs action (See https://github.com/hemilabs/actions/pull/15), we can now rollback the commit 2978962662f444d20652ddc91657e06fbfb77b80 added in #5  to test this.

The `.npmrc` file is no longer needed because the action itself provides that option.

No need to publish a new version