### PR TITLE
Add missing permissions for npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,5 +7,8 @@ on:
 
 jobs:
   npm-publish:
-    uses: hemilabs/actions/.github/workflows/npm-publish.yml@main
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
+    uses: hemilabs/actions/.github/workflows/npm-publish.yml@main


### PR DESCRIPTION
After #6, we need to set the appropriate permissions by using the provenance publishing option from `hemilabs/actions`.

This PR does that

There's no need to publish a new version.